### PR TITLE
fix #205 - move `skipping auto-backup` message to debug

### DIFF
--- a/src/main/java/net/pcal/fastback/ModContext.java
+++ b/src/main/java/net/pcal/fastback/ModContext.java
@@ -75,10 +75,11 @@ public class ModContext {
                     final Duration timeRemaining = config.autobackWait().
                             minus(Duration.ofMillis(System.currentTimeMillis() - lastBackupTime));
                     if (!timeRemaining.isZero() && !timeRemaining.isNegative()) {
-                    //Spam the console every 5 minutes. Super annoying.
+                    //Changes info to debug. This prevents it from sending into the console.
+                    //Before, it would spam the console every 5 minutes. Super annoying.
                     //If you wanted it to backup every 12 hours, you would have 144 logs
-                       // getLogger().info("Skipping auto-backup until at least " +
-                               // (timeRemaining.toSeconds() / 60) + " more minutes have elapsed.");
+                        getLogger().debbug("Skipping auto-backup until at least " +
+                                (timeRemaining.toSeconds() / 60) + " more minutes have elapsed.");
                         return;
                     }
                     getLogger().info("Starting auto-backup");

--- a/src/main/java/net/pcal/fastback/ModContext.java
+++ b/src/main/java/net/pcal/fastback/ModContext.java
@@ -78,7 +78,7 @@ public class ModContext {
                     //Changes info to debug. This prevents it from sending into the console.
                     //Before, it would spam the console every 5 minutes. Super annoying.
                     //If you wanted it to backup every 12 hours, you would have 144 logs
-                        getLogger().debbug("Skipping auto-backup until at least " +
+                        getLogger().debug("Skipping auto-backup until at least " +
                                 (timeRemaining.toSeconds() / 60) + " more minutes have elapsed.");
                         return;
                     }

--- a/src/main/java/net/pcal/fastback/ModContext.java
+++ b/src/main/java/net/pcal/fastback/ModContext.java
@@ -75,8 +75,10 @@ public class ModContext {
                     final Duration timeRemaining = config.autobackWait().
                             minus(Duration.ofMillis(System.currentTimeMillis() - lastBackupTime));
                     if (!timeRemaining.isZero() && !timeRemaining.isNegative()) {
-                        getLogger().info("Skipping auto-backup until at least " +
-                                (timeRemaining.toSeconds() / 60) + " more minutes have elapsed.");
+                    //Spam the console every 5 minutes. Super annoying.
+                    //If you wanted it to backup every 12 hours, you would have 144 logs
+                       // getLogger().info("Skipping auto-backup until at least " +
+                               // (timeRemaining.toSeconds() / 60) + " more minutes have elapsed.");
                         return;
                     }
                     getLogger().info("Starting auto-backup");

--- a/src/main/java/net/pcal/fastback/ModContext.java
+++ b/src/main/java/net/pcal/fastback/ModContext.java
@@ -75,9 +75,6 @@ public class ModContext {
                     final Duration timeRemaining = config.autobackWait().
                             minus(Duration.ofMillis(System.currentTimeMillis() - lastBackupTime));
                     if (!timeRemaining.isZero() && !timeRemaining.isNegative()) {
-                    //Changes info to debug. This prevents it from sending into the console.
-                    //Before, it would spam the console every 5 minutes. Super annoying.
-                    //If you wanted it to backup every 12 hours, you would have 144 logs
                         getLogger().debug("Skipping auto-backup until at least " +
                                 (timeRemaining.toSeconds() / 60) + " more minutes have elapsed.");
                         return;


### PR DESCRIPTION
This is a temporary fix. You can easily make it toggleable from the config or with a little command. Or just hard set it like this to not let it log.