### PR TITLE
disable gpgsign on repo initialization

### DIFF
--- a/src/main/java/net/pcal/fastback/commands/EnableCommand.java
+++ b/src/main/java/net/pcal/fastback/commands/EnableCommand.java
@@ -66,6 +66,7 @@ enum EnableCommand implements Command {
                         if (worldConfig.shutdownAction() == null) {
                             WorldConfig.setShutdownAction(config, SchedulableAction.DEFAULT_SHUTDOWN_ACTION);
                         }
+                        config.setBoolean("commit", null, "gpgsign", false);
                         config.save();
                         log.chat(localized("fastback.chat.enable-done"));
                     } catch (GitAPIException | IOException e) {


### PR DESCRIPTION
Took me a bit, but after our discussion earlier I eventually figured out how to fix the immediate issue. It's a cheap and hacky solution, and it won't help *if* similar cases come up in the future, but it does work.

I know you said you're wary about adding this, so you don't have to merge this if you don't want to, but now you have the option in case you change your mind.


Fixes #165 (kind of)