### PR TITLE
 fix #253 - call `git --version` for compatibility with git versions older than 2.37

### DIFF
--- a/src/main/java/net/pcal/fastback/utils/EnvironmentUtils.java
+++ b/src/main/java/net/pcal/fastback/utils/EnvironmentUtils.java
@@ -37,7 +37,7 @@ public class EnvironmentUtils {
     }
 
     public static String getGitLfsVersion() {
-        return execForVersion(new String[]{"git-lfs", "-v"});
+        return execForVersion(new String[]{"git-lfs", "--version"});
     }
 
     private static String execForVersion(String[] cmd) {

--- a/src/main/java/net/pcal/fastback/utils/EnvironmentUtils.java
+++ b/src/main/java/net/pcal/fastback/utils/EnvironmentUtils.java
@@ -33,7 +33,7 @@ public class EnvironmentUtils {
     }
 
     public static String getGitVersion() {
-        return execForVersion(new String[]{"git", "-v"});
+        return execForVersion(new String[]{"git", "--version"});
     }
 
     public static String getGitLfsVersion() {


### PR DESCRIPTION
git -v appears to return `unknown option: -v` on my system, whereas git --version works properly. This PR allows native git support to work.