### PR TITLE
Fix outdated docs

### DIFF
--- a/docs/diskspace.md
+++ b/docs/diskspace.md
@@ -25,10 +25,10 @@ from the last 3 days. All other snapshots will be removed.
 
 ## Changing How Snapshots are Retained
 
-You can change the rules for retaining snapshots by running `set-retention`:
+You can change the rules for retaining snapshots by running `set retention-policy`:
 
 ```
-/backup set-retention [policy] [arguments...]
+/backup set retention-policy [policy] [arguments...]
 ```
 
 Where `[policy]` is one of
@@ -38,7 +38,7 @@ Where `[policy]` is one of
 For example, to change the policy to keep the five most-recent snapshots, run:
 
 ```
-/backup set-retention fixed 5
+/backup set retention-policy fixed 5
 ```
 
 ## Collecting Garbage
@@ -56,10 +56,10 @@ you may be better off running `git gc` from the command line instead.
 ## Managing Snapshots on a Remote
 
 You can also manage snapshots on a remote backup on a similar way using the
-`set-remote-retention` and `remote-prune` commands. For example,
+`set remote-retention-policy` and `remote-prune` commands. For example,
 
 ```
-/backup set-remote-retention daily 7
+/backup set remote-retention-policy daily 7
 ```
 
 will set the retention policy for snapshots in the remote backup to keep all snapshots for the last 7 days


### PR DESCRIPTION
The instructions in the category "[Disk Space](https://pcal43.github.io/fastback/diskspace.html)" is also incorrect. It's using "set-retention" instead of "set retention-policy". It's also the same for "set-remote-retention" which should be "remote-retention-policy"

https://github.com/pcal43/fastback/issues/270#issuecomment-1722477928