### PR TITLE
fix git-lfs not being detected on windows

### DIFF
--- a/common/src/main/java/net/pcal/fastback/utils/EnvironmentUtils.java
+++ b/common/src/main/java/net/pcal/fastback/utils/EnvironmentUtils.java
@@ -41,7 +41,7 @@ public class EnvironmentUtils {
     }
 
     public static String getGitLfsVersion() {
-        return execForVersion(new String[]{"git-lfs", "--version"});
+        return execForVersion(new String[]{"git", "lfs", "--version"});
     }
 
     /**


### PR DESCRIPTION
On windows `git-lfs` is not a command, however (exclusively) on windows, git comes with `lfs` bundled into it by default, so `git lfs`, with a space, is needed

this does indeed work on linux as well,
![image](https://github.com/pcal43/fastback/assets/10422110/9488fffd-5635-48f0-948b-cabee69d35e0)
left is a linux machine right is my local windows machine, 