### PR TITLE
Merith/fix322

### DIFF
--- a/common/src/main/java/net/pcal/fastback/config/GitConfigImpl.java
+++ b/common/src/main/java/net/pcal/fastback/config/GitConfigImpl.java
@@ -36,7 +36,7 @@ class GitConfigImpl implements GitConfig {
         return new GitConfigImpl(jgit.getRepository().getConfig());
     }
 
-    private final StoredConfig storedConfig;
+    public final StoredConfig storedConfig;
 
     GitConfigImpl(StoredConfig jgitConfig) {
         this.storedConfig = requireNonNull(jgitConfig);

--- a/common/src/main/java/net/pcal/fastback/config/OtherConfigKey.java
+++ b/common/src/main/java/net/pcal/fastback/config/OtherConfigKey.java
@@ -37,7 +37,11 @@ public enum OtherConfigKey implements GitConfigKey {
     /**
      * We disable commit signing on git init.  https://github.com/pcal43/fastback/issues/165
      */
-    COMMIT_SIGNING_ENABLED("commit", null, "gpgsign");
+    COMMIT_SIGNING_ENABLED("commit", null, "gpgsign"),
+
+    // Allow reading the user's name and email from .gitconfig
+    USER_NAME("user", null, "name"),
+    USER_EMAIL("user", null, "email");
 
     private final String sectionName, subSectionName, settingName;
 

--- a/common/src/main/java/net/pcal/fastback/repo/RepoFactoryImpl.java
+++ b/common/src/main/java/net/pcal/fastback/repo/RepoFactoryImpl.java
@@ -65,6 +65,8 @@ class RepoFactoryImpl implements RepoFactory {
             String userName = config.getString("user", null, "name");
             String userEmail = config.getString("user", null, "email");
 
+            // If they don't have name/email set (as most non-git-users won't), provide synthetic values as a convenience.
+            // Presumbably, most folks don't care.
             if (userName == null || userName.isEmpty() || userEmail == null || userEmail.isEmpty()) {
                 // set from fastback world id
                 String worldId = WorldIdUtils.getWorldIdInfo(worldSaveDir).wid().toString();

--- a/common/src/main/java/net/pcal/fastback/repo/RepoFactoryImpl.java
+++ b/common/src/main/java/net/pcal/fastback/repo/RepoFactoryImpl.java
@@ -19,9 +19,11 @@
 package net.pcal.fastback.repo;
 
 import net.pcal.fastback.config.GitConfig.Updater;
+import net.pcal.fastback.config.GitConfigKey;
 import net.pcal.fastback.logging.UserLogger;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.StoredConfig;
 
 import java.io.File;
 import java.io.IOException;
@@ -58,6 +60,17 @@ class RepoFactoryImpl implements RepoFactory {
             final Updater updater = repo.getConfig().updater();
             updater.set(COMMIT_SIGNING_ENABLED, false); // because some people have it set globally
             updater.set(IS_NATIVE_GIT_ENABLED, true);
+
+            StoredConfig config = jgit.getRepository().getConfig();
+            String userName = config.getString("user", null, "name");
+            String userEmail = config.getString("user", null, "email");
+
+            if (userName == null || userName.isEmpty() || userEmail == null || userEmail.isEmpty()) {
+                // set from fastback world id
+                String worldId = WorldIdUtils.getWorldIdInfo(worldSaveDir).wid().toString();
+                config.setString("user", null, "name", worldId);
+                config.setString("user", null, "email", worldId + "@fastback");
+            }
             updater.save();
             ulog.message(raw("Backups initialized.  Run '/backup local' to do your first backup.  '/backup help' for more options."));
         } catch (GitAPIException e) {

--- a/common/src/main/java/net/pcal/fastback/utils/ProcessUtils.java
+++ b/common/src/main/java/net/pcal/fastback/utils/ProcessUtils.java
@@ -51,8 +51,14 @@ public class ProcessUtils {
         // Output a few values that are important for debugging; don't indiscriminately dump everything or someone's going
         // to end up uploading a bunch of passwords into pastebin.
         syslog().debug("PATH: " + env.get("PATH"));
-        syslog().debug("USER: " + env.get("USER"));
-        syslog().debug("HOME: " + env.get("HOME"));
+        if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+            syslog().debug("HOME: " + env.get("USERPROFILE"));
+            syslog().debug("USER: " + env.get("USERNAME"));
+        } else {
+            syslog().debug("HOME: " + env.get("HOME"));
+            syslog().debug("USER: " + env.get("USER"));
+        }
+
         final List<String> errorBuffer = new ArrayList<>();
         final Consumer<String> stdout = line -> {
             syslog().debug("[STDOUT] " + line);


### PR DESCRIPTION
Fixes #322 

## Fix: ImproperVariables
* Added a check if host is windows, and to use the proper variables there.
* Visually nothing has changed, output will still look like `HOME: C:/Users/Username`

## Fix: Missing GitConfig Entries prevent commit
* Fixes #272 
* When user.email and user.name are not found, git would fail to commit and throw the error to the logs, while the user would be told both "error running command" AND "backup successful"
* I set these values in the worlds gitconfig on `init` as the following
  * `user.name`: `<fastbackWorldID>`
  * `user.email`: `<fastbackWorldID>@fastback`
* I only do this on init to allow for users *manually* altering the config. 