### PR TITLE
ignore build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ build/
 out/
 classes/
 
+*/bin
+
 # eclipse
 
 *.launch

--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,6 @@ build/
 out/
 classes/
 
-*/bin
-
 # eclipse
 
 *.launch
@@ -25,11 +23,11 @@ classes/
 *.iws
 
 # vscode
-
 .settings/
 .vscode/
 .classpath
 .project
+*/bin
 
 # macos
 


### PR DESCRIPTION
I noticed this when opening with gitpod and building that the compiled classes are not ignored lol

![image](https://github.com/pcal43/fastback/assets/10422110/61c72f16-c112-4f43-8b87-fdfa51e3a0c9)