### PR TITLE
fix #326 - cache git/lfs versions

### DIFF
--- a/common/src/main/java/net/pcal/fastback/commands/InfoCommand.java
+++ b/common/src/main/java/net/pcal/fastback/commands/InfoCommand.java
@@ -28,6 +28,7 @@ import net.pcal.fastback.repo.Repo;
 import net.pcal.fastback.retention.RetentionPolicy;
 import net.pcal.fastback.retention.RetentionPolicyCodec;
 import net.pcal.fastback.retention.RetentionPolicyType;
+import net.pcal.fastback.utils.EnvironmentUtils;
 
 import java.util.function.Function;
 
@@ -75,6 +76,8 @@ enum InfoCommand implements Command {
             try {
                 ulog.message(UserMessage.localized("fastback.chat.info-header"));
                 ulog.message(UserMessage.localized("fastback.chat.info-fastback-version", mod().getModVersion()));
+                gitVersion = getGitVersion();
+                gitLfsVersion = getGitLfsVersion();
                 if (!rf().isGitRepo(mod().getWorldDirectory())) {
                     // If they haven't yet run 'backup init', make sure they've installed native.
                     if (!isNativeOk(true, ulog, true)) return FAILURE;

--- a/common/src/main/java/net/pcal/fastback/mod/ModImpl.java
+++ b/common/src/main/java/net/pcal/fastback/mod/ModImpl.java
@@ -24,6 +24,7 @@ import net.pcal.fastback.logging.UserLogger;
 import net.pcal.fastback.logging.UserMessage;
 import net.pcal.fastback.repo.Repo;
 import net.pcal.fastback.repo.RepoFactory;
+import net.pcal.fastback.utils.EnvironmentUtils;
 import org.eclipse.jgit.transport.SshSessionFactory;
 
 import java.io.IOException;
@@ -37,8 +38,7 @@ import static net.pcal.fastback.config.FastbackConfigKey.IS_BACKUP_ENABLED;
 import static net.pcal.fastback.config.FastbackConfigKey.SHUTDOWN_ACTION;
 import static net.pcal.fastback.logging.SystemLogger.syslog;
 import static net.pcal.fastback.logging.UserMessage.localized;
-import static net.pcal.fastback.utils.EnvironmentUtils.getGitLfsVersion;
-import static net.pcal.fastback.utils.EnvironmentUtils.getGitVersion;
+import static net.pcal.fastback.utils.EnvironmentUtils.*;
 import static net.pcal.fastback.utils.Executor.executor;
 
 class ModImpl implements LifecycleListener, Mod {
@@ -147,7 +147,7 @@ class ModImpl implements LifecycleListener, Mod {
     @Override
     public void onInitialize() {
         {
-            final String gitVersion = getGitVersion();
+            gitVersion = getGitVersion();
             if (gitVersion == null) {
                 syslog().warn("git is not installed.");
             } else {
@@ -155,7 +155,7 @@ class ModImpl implements LifecycleListener, Mod {
             }
         }
         {
-            final String gitLfsVersion = getGitLfsVersion();
+            gitLfsVersion = getGitLfsVersion();
             if (gitLfsVersion == null) {
                 syslog().warn("git-lfs is not installed.");
             } else {

--- a/common/src/main/java/net/pcal/fastback/utils/EnvironmentUtils.java
+++ b/common/src/main/java/net/pcal/fastback/utils/EnvironmentUtils.java
@@ -36,6 +36,9 @@ import static net.pcal.fastback.utils.ProcessUtils.doExec;
 
 public class EnvironmentUtils {
 
+    public static String gitVersion;
+    public static String gitLfsVersion;
+
     public static String getGitVersion() {
         return execForVersion(new String[]{"git", "--version"});
     }
@@ -57,8 +60,11 @@ public class EnvironmentUtils {
     public static boolean isNativeOk(boolean isNativeGitEnabled, UserLogger ulog, boolean verbose) {
         if (isNativeGitEnabled) {
             final Component notInstalled = Component.translatable("fastback.values.not-installed");
-            final String gitVersion = getGitVersion();
-            final String gitLfsVersion = getGitLfsVersion();
+            // if gitVersion or gitLfsVersion is null, then run the check again
+            if (gitVersion == null || gitLfsVersion == null) {
+                gitVersion = getGitVersion();
+                gitLfsVersion = getGitLfsVersion();
+            }
             final boolean isNativeInstalled = (gitVersion != null && gitLfsVersion != null);
             if (verbose || !isNativeInstalled) {
                 ulog.message(localized("fastback.chat.info-native-git-version", gitVersion != null ? gitVersion : notInstalled));


### PR DESCRIPTION
cache initial git --version check from onInitialize, reload value with `backup info`

helps keep debug logs clean, 