### PR TITLE
Add skip to native git-lfs install

### DIFF
--- a/common/src/main/java/net/pcal/fastback/commands/SetCommand.java
+++ b/common/src/main/java/net/pcal/fastback/commands/SetCommand.java
@@ -48,6 +48,7 @@ import static net.pcal.fastback.commands.Commands.SUCCESS;
 import static net.pcal.fastback.commands.Commands.getArgumentNicely;
 import static net.pcal.fastback.commands.Commands.missingArgument;
 import static net.pcal.fastback.commands.Commands.subcommandPermission;
+import static net.pcal.fastback.config.FastbackConfigKey.AUTO_GITLFS_INSTALL;
 import static net.pcal.fastback.config.FastbackConfigKey.AUTOBACK_ACTION;
 import static net.pcal.fastback.config.FastbackConfigKey.AUTOBACK_WAIT_MINUTES;
 import static net.pcal.fastback.config.FastbackConfigKey.BROADCAST_ENABLED;
@@ -87,6 +88,7 @@ enum SetCommand implements Command {
         final LiteralArgumentBuilder<CommandSourceStack> sc = literal(COMMAND_NAME).
                 requires(subcommandPermission(COMMAND_NAME, pf)).
                 executes(cc -> missingArgument("key", cc));
+        registerBooleanConfigValue(AUTO_GITLFS_INSTALL, sc);
         registerBooleanConfigValue(IS_LOCK_CLEANUP_ENABLED, sc);
         registerBooleanConfigValue(IS_BACKUP_ENABLED, sc);
         registerBooleanConfigValue(IS_MODS_BACKUP_ENABLED, sc);

--- a/common/src/main/java/net/pcal/fastback/config/FastbackConfigKey.java
+++ b/common/src/main/java/net/pcal/fastback/config/FastbackConfigKey.java
@@ -25,6 +25,7 @@ package net.pcal.fastback.config;
  */
 public enum FastbackConfigKey implements GitConfigKey {
 
+    AUTO_GITLFS_INSTALL("auto-gitlfs-install",true),
     AUTOBACK_ACTION("autoback-action", null),
     AUTOBACK_WAIT_MINUTES("autoback-wait", 0),
     BROADCAST_ENABLED("broadcast-enabled", true),

--- a/common/src/main/java/net/pcal/fastback/repo/CommitUtils.java
+++ b/common/src/main/java/net/pcal/fastback/repo/CommitUtils.java
@@ -123,7 +123,10 @@ abstract class CommitUtils {
         ulog.update(styledLocalized("fastback.hud.local-saving", NATIVE_GIT));
         final File worktree = repo.getWorkTree();
         final Map<String, String> env = Map.of("GIT_LFS_FORCE_PROGRESS", "1");
-        final Consumer<String> outputConsumer = line -> ulog.update(styledRaw(line, NATIVE_GIT));
+        final Consumer<String> outputConsumer = line -> {
+        	ulog.update(styledRaw(line, NATIVE_GIT));
+        	syslog().info(line);
+        };
         String[] checkout = {"git", "-C", worktree.getAbsolutePath(), "checkout", "--orphan", newBranchName};
         try {
             doExec(checkout, env, outputConsumer, outputConsumer);

--- a/common/src/main/java/net/pcal/fastback/repo/PreflightUtils.java
+++ b/common/src/main/java/net/pcal/fastback/repo/PreflightUtils.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import static net.pcal.fastback.config.FastbackConfigKey.IS_NATIVE_GIT_ENABLED;
 import static net.pcal.fastback.config.FastbackConfigKey.UPDATE_GITATTRIBUTES_ENABLED;
 import static net.pcal.fastback.config.FastbackConfigKey.UPDATE_GITIGNORE_ENABLED;
+import static net.pcal.fastback.config.FastbackConfigKey.AUTO_GITLFS_INSTALL;
 import static net.pcal.fastback.logging.SystemLogger.syslog;
 import static net.pcal.fastback.utils.FileUtils.writeResourceToFile;
 import static net.pcal.fastback.utils.ProcessUtils.doExec;

--- a/common/src/main/java/net/pcal/fastback/repo/PreflightUtils.java
+++ b/common/src/main/java/net/pcal/fastback/repo/PreflightUtils.java
@@ -74,7 +74,8 @@ abstract class PreflightUtils {
                 writeResourceToFile("world/gitattributes-jgit", targetPath);
             }
         }
-        updateNativeLfsInstallation(repo);
+        if (config.getBoolean(AUTO_GITLFS_INSTALL))
+            updateNativeLfsInstallation(repo);
     }
 
     // ======================================================================

--- a/common/src/main/java/net/pcal/fastback/repo/PreflightUtils.java
+++ b/common/src/main/java/net/pcal/fastback/repo/PreflightUtils.java
@@ -101,12 +101,34 @@ abstract class PreflightUtils {
         }
     }
 
+    /**
+     * <p>The native git-lfs updater called every preflight
+     * (<b>WHICH CAN SKIP THE GIT-LFS INSTALL</b>)
+     * </p>
+     * @author Helcostr
+     * @param repo The FastBack repository
+     * @see net.pcal.fastback.repo.PreflightUtils.nativeGitLfsHookCheck(File)
+     * @since 0.19.1
+     * @throws IOException
+     * @throws ProcessException
+     */
     private static void nativeGitLfsUpdater(final RepoImpl repo) throws IOException, ProcessException {
     	if (!nativeGitLfsHookCheck(repo.getDirectory())) {
     		final String[] cmd = {"git", "-C", repo.getWorkTree().getAbsolutePath(), "lfs", "install", "--local"};
         	doExec(cmd, Collections.emptyMap(), s -> {}, s -> {});
     	}
     }
+    /**
+     * <p>Boolean indicating that we can skip GitLFS install
+     * based on checking the hook file
+     * </p>
+     * @author Helcostr
+     * @param dir of git metadata (org.eclipse.jgit.lib.Repository.getDirectory())
+     * @see net.pcal.fastback.repo.PreflightUtils.nativeGitLfsUpdater(RepoImpl)
+     * @since 0.19.1
+     * @return Valid GitLFS
+     * @throws IOException
+     */
     private static boolean nativeGitLfsHookCheck(File dir) throws IOException {
     	File hooksDir = new File(dir, "hooks");
     	String[] hookNames = {"pre-push", "post-checkout", "post-commit", "post-merge"};

--- a/common/src/main/java/net/pcal/fastback/repo/PreflightUtils.java
+++ b/common/src/main/java/net/pcal/fastback/repo/PreflightUtils.java
@@ -21,13 +21,13 @@ package net.pcal.fastback.repo;
 import net.pcal.fastback.config.GitConfig;
 import net.pcal.fastback.logging.SystemLogger;
 import net.pcal.fastback.utils.ProcessException;
+import org.eclipse.jgit.hooks.*;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.StoredConfig;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 
 import static net.pcal.fastback.config.FastbackConfigKey.IS_NATIVE_GIT_ENABLED;
 import static net.pcal.fastback.config.FastbackConfigKey.UPDATE_GITATTRIBUTES_ENABLED;
@@ -81,8 +81,7 @@ abstract class PreflightUtils {
      */
     private static void updateNativeLfsInstallation(final RepoImpl repo) throws ProcessException, GitAPIException {
         if (repo.getConfig().getBoolean(IS_NATIVE_GIT_ENABLED)) {
-            final String[] cmd = {"git", "-C", repo.getWorkTree().getAbsolutePath(), "lfs", "install", "--local"};
-            doExec(cmd, Collections.emptyMap(), s -> {}, s -> {});
+        	nativeGitLfsUpdater(repo);
         } else {
             try {
                 // jgit has builtin support for lfs, but it's weird not compatible with native lfs, so lets just
@@ -95,5 +94,11 @@ abstract class PreflightUtils {
                 syslog().debug(ohwell);
             }
         }
+    }
+
+    private static void nativeGitLfsUpdater(final RepoImpl repo) {
+    	PrePushHook test = Hooks.prePush(repo.getJGit().getRepository(), null);
+    	syslog().error(test.getHookName());
+    	syslog().error(test.toString());
     }
 }

--- a/common/src/main/resources/assets/fastback/lang/en_us.json
+++ b/common/src/main/resources/assets/fastback/lang/en_us.json
@@ -16,6 +16,7 @@
   "fastback.help.command.remote-restore"         : "Restore a remote snapshot.",
   "fastback.help.command.restore"                : "Restore a backup snapshot.",
   "fastback.help.command.set"                    : "Change configuration settings.",
+  "fastback.help.command.set-auto-gitlfs-install": "Allows for auto resolution of gitlfs install.",
   "fastback.help.command.set-autoback-action"    : "Set an action to perform during auto-backups.",
   "fastback.help.command.set-autoback-wait"      : "Set the minimum number of minutes to wait between auto-backups.",
   "fastback.help.command.set-remote"             : "Set the url for remote backups.",


### PR DESCRIPTION
# Summary
- Skips native git-lfs install if hooks contain git lfs hooks
- Provide the config option `auto-gitlfs-install`

# Details
Forcing default git-lfs hooks during preflight causes issues with custom hooks.

```
[04:11:29] [pool-4-thread-2/ERROR]: [STDERR] Hook already exists: pre-push
[04:11:29] [pool-4-thread-2/ERROR]: [STDERR] #!/bin/sh
[04:11:29] [pool-4-thread-2/ERROR]: [STDERR] command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n"; exit 2; }
[04:11:29] [pool-4-thread-2/ERROR]: [STDERR] git lfs pre-push "$@"
[04:11:29] [pool-4-thread-2/ERROR]: [STDERR] To resolve this, either:
[04:11:29] [pool-4-thread-2/ERROR]: [STDERR] 1: run `git lfs update --manual` for instructions on how to merge hooks.
[04:11:29] [pool-4-thread-2/ERROR]: [STDERR] 2: run `git lfs update --force` to overwrite your hook.
```

By checking for default git-lfs hooks in the contents of the files, we can skip a bad git-lfs attempted override.

The following three states will happen:

- No Git-LFS hooks
	- Installs 4 fresh Git-LFS hooks no issue
- Hooks that don't contain one or more Git-LFS hooks
	- Fails as Git-LFS install fails (we assume the user is advance, and needs to merge their own hooks)
	- TODO: add custom message to identify such an issue?
- Has Git-LFS hooks
	- Continues with backup, even though the install would have potentially failed.
	
In addition, allows advance users to ignore a forced git-lfs assurance via the `auto-gitlfs-install` config (set to false will disable it).
# Bug Fixes
Allows for the ignoring of bad git-lfs re-install even though the hooks are still git-lfs functional.