### PR TITLE
fix: throwOnNonZero is never used

### DIFF
--- a/common/src/main/java/net/pcal/fastback/utils/ProcessUtils.java
+++ b/common/src/main/java/net/pcal/fastback/utils/ProcessUtils.java
@@ -77,7 +77,7 @@ public class ProcessUtils {
         } catch (IOException | InterruptedException e) {
             throw new ProcessException(args, 0, errorBuffer, e);
         }
-        if (exit != 0) {
+        if (exit != 0 && throwOnNonZero) {
             throw new ProcessException(args, exit, errorBuffer);
         }
         return exit;

--- a/common/src/main/java/net/pcal/fastback/utils/ProcessUtils.java
+++ b/common/src/main/java/net/pcal/fastback/utils/ProcessUtils.java
@@ -77,7 +77,7 @@ public class ProcessUtils {
         } catch (IOException | InterruptedException e) {
             throw new ProcessException(args, 0, errorBuffer, e);
         }
-        if (exit != 0 && throwOnNonZero) {
+        if (throwOnNonZero && exit != 0) {
             throw new ProcessException(args, exit, errorBuffer);
         }
         return exit;


### PR DESCRIPTION
See title. throwOnNonZero argument on ProcessUtils.doExec is never used