### PR TITLE
add git-native implementations for remote operations

### DIFF
--- a/common/src/main/java/net/pcal/fastback/repo/BranchUtils.java
+++ b/common/src/main/java/net/pcal/fastback/repo/BranchUtils.java
@@ -40,11 +40,11 @@ abstract class BranchUtils {
     /**
      * Get the snapshots for this repo.  Snapshot branches for worlds other than the Repo's are ignored.
      */
-    static Set<SnapshotId> listSnapshots(RepoImpl repo, JGitSupplier<Collection<Ref>> refProvider) throws GitAPIException, IOException {
-        final Collection<Ref> refs = refProvider.get();
+    static Set<SnapshotId> listSnapshots(RepoImpl repo, JGitSupplier<Collection<String>> refProvider) throws GitAPIException, IOException {
+        final Collection<String> refs = refProvider.get();
         final SnapshotIdCodec codec = repo.getSidCodec();
         final Set<SnapshotId> out = new HashSet<>();
-        for (final Ref ref : refs) {
+        for (final String ref : refs) {
             String branchName = getBranchName(ref);
             if (repo.getSidCodec().isSnapshotBranchName(repo.getWorldId(), branchName)) {
                 final SnapshotId sid;
@@ -67,8 +67,11 @@ abstract class BranchUtils {
     }
 
     static String getBranchName(Ref fromBranchRef) {
+        return getBranchName(fromBranchRef.getName());
+    }
+
+    static String getBranchName(String name) {
         final String REFS_HEADS = "refs/heads/";
-        final String name = fromBranchRef.getName();
         if (name.startsWith(REFS_HEADS)) {
             return name.substring(REFS_HEADS.length());
         } else {

--- a/common/src/main/java/net/pcal/fastback/repo/PruneUtils.java
+++ b/common/src/main/java/net/pcal/fastback/repo/PruneUtils.java
@@ -25,6 +25,8 @@ import net.pcal.fastback.logging.UserMessage;
 import net.pcal.fastback.retention.RetentionPolicy;
 import net.pcal.fastback.retention.RetentionPolicyCodec;
 import net.pcal.fastback.retention.RetentionPolicyType;
+import net.pcal.fastback.utils.ProcessException;
+import net.pcal.fastback.utils.ProcessUtils;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.transport.RefSpec;
 
@@ -35,11 +37,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import static net.pcal.fastback.config.FastbackConfigKey.LOCAL_RETENTION_POLICY;
-import static net.pcal.fastback.config.FastbackConfigKey.REMOTE_NAME;
+import static net.pcal.fastback.config.FastbackConfigKey.*;
 import static net.pcal.fastback.logging.SystemLogger.syslog;
 import static net.pcal.fastback.logging.UserMessage.UserMessageStyle.ERROR;
 import static net.pcal.fastback.logging.UserMessage.styledLocalized;
+import static org.apache.commons.lang3.function.Consumers.nop;
 
 /**
  * Utils for pruning and deleting snapshot branches.
@@ -50,14 +52,28 @@ import static net.pcal.fastback.logging.UserMessage.styledLocalized;
 abstract class PruneUtils {
 
     static void deleteRemoteBranch(final RepoImpl repo, String remoteBranchName) throws IOException {
+        GitConfig config = repo.getConfig();
+        try {
+            if (config.getBoolean(IS_NATIVE_GIT_ENABLED)) {
+                native_deleteRemoteBranch(repo, remoteBranchName);
+            } else {
+                jgit_deleteRemoteBranch(repo, remoteBranchName);
+            }
+        } catch (GitAPIException | ProcessException e) {
+            throw new IOException(e);
+        }
+    }
+
+    static void native_deleteRemoteBranch(final RepoImpl repo, String remoteBranchName) throws ProcessException {
+        String[] command = {"git", "push", repo.getConfig().getString(REMOTE_NAME), "--delete", remoteBranchName};
+        ProcessUtils.doExec(command, Collections.emptyMap(), nop(), nop(), true, repo.getWorkTree());
+    }
+
+    static void jgit_deleteRemoteBranch(final RepoImpl repo, String remoteBranchName) throws GitAPIException {
         RefSpec refSpec = new RefSpec()
                 .setSource(null)
                 .setDestination("refs/heads/" + remoteBranchName);
-        try {
-            repo.getJGit().push().setRefSpecs(refSpec).setRemote(repo.getConfig().getString(REMOTE_NAME)).call();
-        } catch (GitAPIException e) {
-            throw new IOException(e);
-        }
+        repo.getJGit().push().setRefSpecs(refSpec).setRemote(remoteBranchName).call();
     }
 
     static void deleteLocalBranches(final RepoImpl repo, List<String> branchNames) throws IOException {

--- a/common/src/main/java/net/pcal/fastback/repo/PruneUtils.java
+++ b/common/src/main/java/net/pcal/fastback/repo/PruneUtils.java
@@ -65,8 +65,8 @@ abstract class PruneUtils {
     }
 
     static void native_deleteRemoteBranch(final RepoImpl repo, String remoteBranchName) throws ProcessException {
-        String[] command = {"git", "push", repo.getConfig().getString(REMOTE_NAME), "--delete", remoteBranchName};
-        ProcessUtils.doExec(command, Collections.emptyMap(), nop(), nop(), true, repo.getWorkTree());
+        String[] command = {"git", "-C", repo.getWorkTree().getAbsolutePath(), "push", repo.getConfig().getString(REMOTE_NAME), "--delete", remoteBranchName};
+        ProcessUtils.doExec(command, Collections.emptyMap(), nop(), nop(), true);
     }
 
     static void jgit_deleteRemoteBranch(final RepoImpl repo, String remoteBranchName) throws GitAPIException {

--- a/common/src/main/java/net/pcal/fastback/repo/PushUtils.java
+++ b/common/src/main/java/net/pcal/fastback/repo/PushUtils.java
@@ -163,7 +163,7 @@ abstract class PushUtils {
                     }
                 },
                 unused -> {},
-                true,
+                false,
                 repo.getWorkTree()
         );
         return result;

--- a/common/src/main/java/net/pcal/fastback/repo/PushUtils.java
+++ b/common/src/main/java/net/pcal/fastback/repo/PushUtils.java
@@ -147,7 +147,7 @@ abstract class PushUtils {
     }
 
     static Collection<String> native_lsRemote(final Repo repo, final String remote, final boolean heads, final boolean tags) throws ProcessException {
-        List<String> command = new ArrayList<>(asList("git", "ls-remote"));
+        List<String> command = new ArrayList<>(asList("git", "-C", repo.getWorkTree().getAbsolutePath(), "ls-remote"));
         addIf(command, heads, "--branches");
         addIf(command, tags, "--tags");
         command.add(remote);
@@ -163,8 +163,7 @@ abstract class PushUtils {
                     }
                 },
                 unused -> {},
-                false,
-                repo.getWorkTree()
+                false
         );
         return result;
     }

--- a/common/src/main/java/net/pcal/fastback/repo/RepoImpl.java
+++ b/common/src/main/java/net/pcal/fastback/repo/RepoImpl.java
@@ -42,7 +42,10 @@ import java.util.List;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
-import static net.pcal.fastback.config.FastbackConfigKey.*;
+import static net.pcal.fastback.config.FastbackConfigKey.BROADCAST_ENABLED;
+import static net.pcal.fastback.config.FastbackConfigKey.BROADCAST_MESSAGE;
+import static net.pcal.fastback.config.FastbackConfigKey.IS_LOCK_CLEANUP_ENABLED;
+import static net.pcal.fastback.config.FastbackConfigKey.REMOTE_NAME;
 import static net.pcal.fastback.config.OtherConfigKey.REMOTE_PUSH_URL;
 import static net.pcal.fastback.logging.SystemLogger.syslog;
 import static net.pcal.fastback.logging.UserMessage.UserMessageStyle.BROADCAST;

--- a/common/src/main/java/net/pcal/fastback/repo/SnapshotIdUtils.java
+++ b/common/src/main/java/net/pcal/fastback/repo/SnapshotIdUtils.java
@@ -21,7 +21,6 @@ package net.pcal.fastback.repo;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import net.pcal.fastback.repo.WorldIdUtils.WorldIdImpl;
-import org.eclipse.jgit.lib.Ref;
 
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -32,9 +31,9 @@ import static net.pcal.fastback.logging.SystemLogger.syslog;
 
 abstract class SnapshotIdUtils {
 
-    static ListMultimap<WorldId, SnapshotId> getSnapshotsPerWorld(Iterable<Ref> refs, SnapshotIdCodec codec) {
+    static ListMultimap<WorldId, SnapshotId> getSnapshotsPerWorld(Iterable<String> refs, SnapshotIdCodec codec) {
         final ListMultimap<WorldId, SnapshotId> out = ArrayListMultimap.create();
-        for (final Ref ref : refs) {
+        for (final String ref : refs) {
             final String branchName = BranchUtils.getBranchName(ref);
             if (branchName == null) continue;
             try {

--- a/common/src/main/java/net/pcal/fastback/utils/CollectionUtils.java
+++ b/common/src/main/java/net/pcal/fastback/utils/CollectionUtils.java
@@ -1,0 +1,11 @@
+package net.pcal.fastback.utils;
+
+import java.util.List;
+
+public class CollectionUtils {
+    public static <T> void addIf(List<T> list, boolean expr, T element) {
+        if (expr) {
+            list.add(element);
+        }
+    }
+}

--- a/common/src/main/java/net/pcal/fastback/utils/ProcessUtils.java
+++ b/common/src/main/java/net/pcal/fastback/utils/ProcessUtils.java
@@ -18,10 +18,7 @@
 
 package net.pcal.fastback.utils;
 
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.Writer;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,10 +38,10 @@ import static net.pcal.fastback.logging.SystemLogger.syslog;
 public class ProcessUtils {
 
     public static int doExec(String[] args, final Map<String, String> envOriginal, Consumer<String> stdoutSink, Consumer<String> stderrSink) throws ProcessException {
-        return doExec(args, envOriginal, stdoutSink, stderrSink, true);
+        return doExec(args, envOriginal, stdoutSink, stderrSink, true, null);
     }
 
-    public static int doExec(final String[] args, final Map<String, String> envOriginal, final Consumer<String> stdoutSink, final Consumer<String> stderrSink, boolean throwOnNonZero) throws ProcessException {
+    public static int doExec(final String[] args, final Map<String, String> envOriginal, final Consumer<String> stdoutSink, final Consumer<String> stderrSink, boolean throwOnNonZero, File workDir) throws ProcessException {
         syslog().debug("Executing " + String.join(" ", args));
         final ProcessBuilder pb = new ProcessBuilder(args);
         final Map<String, String> env = pb.environment();
@@ -70,6 +67,8 @@ public class ProcessUtils {
             stderrSink.accept(line);
             errorBuffer.add("[STDERR] " + line);
         };
+        syslog().debug("WORKDIR: " + (workDir != null ? workDir.getAbsolutePath() : null));
+        pb.directory(workDir);
         final int exit;
         try {
             final Process p = pb.start();

--- a/common/src/main/java/net/pcal/fastback/utils/ProcessUtils.java
+++ b/common/src/main/java/net/pcal/fastback/utils/ProcessUtils.java
@@ -38,10 +38,10 @@ import static net.pcal.fastback.logging.SystemLogger.syslog;
 public class ProcessUtils {
 
     public static int doExec(String[] args, final Map<String, String> envOriginal, Consumer<String> stdoutSink, Consumer<String> stderrSink) throws ProcessException {
-        return doExec(args, envOriginal, stdoutSink, stderrSink, true, null);
+        return doExec(args, envOriginal, stdoutSink, stderrSink, true);
     }
 
-    public static int doExec(final String[] args, final Map<String, String> envOriginal, final Consumer<String> stdoutSink, final Consumer<String> stderrSink, boolean throwOnNonZero, File workDir) throws ProcessException {
+    public static int doExec(final String[] args, final Map<String, String> envOriginal, final Consumer<String> stdoutSink, final Consumer<String> stderrSink, boolean throwOnNonZero) throws ProcessException {
         syslog().debug("Executing " + String.join(" ", args));
         final ProcessBuilder pb = new ProcessBuilder(args);
         final Map<String, String> env = pb.environment();
@@ -67,8 +67,6 @@ public class ProcessUtils {
             stderrSink.accept(line);
             errorBuffer.add("[STDERR] " + line);
         };
-        syslog().debug("WORKDIR: " + (workDir != null ? workDir.getAbsolutePath() : null));
-        pb.directory(workDir);
         final int exit;
         try {
             final Process p = pb.start();

--- a/common/src/main/java/net/pcal/fastback/utils/ProcessUtils.java
+++ b/common/src/main/java/net/pcal/fastback/utils/ProcessUtils.java
@@ -18,7 +18,10 @@
 
 package net.pcal.fastback.utils;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
Some low-level Git operations still uses pure JGit implementation, making it not applicable to self-hosted, private git servers.
This PR re-implemented these Git operations using native Git command line, so Git credentials manager will be called as expected and I can authenticate the native Git client.