### PR TITLE
Update for Minecraft 1.21.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -54,7 +54,7 @@ fabric_permissions_version   = 0.4.0
 
 # https://github.com/NucleoidMC/Server-Translations/releases
 # https://maven.nucleoid.xyz/xyz/nucleoid/server-translations-api/
-server_translations_version  = 2.5.2+1.21.6
+server_translations_version  = 2.5.1+1.21.5
 
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -54,7 +54,10 @@ fabric_permissions_version   = 0.4.0
 
 # https://github.com/NucleoidMC/Server-Translations/releases
 # https://maven.nucleoid.xyz/xyz/nucleoid/server-translations-api/
+# NOTE: the 1.21.5 version seems to work ok with 1.21.6 but should be bumped as soon as
+# an update is available.
 server_translations_version  = 2.5.1+1.21.5
+
 
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #
 # Fastback
 #
-mod_version = 0.24.2+1.21.5-prerelease
+mod_version = 0.24.2+1.21.6
 maven_group = net.pcal
 maven_name = fastback
 archives_base_name = fastback
@@ -10,9 +10,9 @@ archives_base_name = fastback
 #
 # Fabric & Minecraft - https://fabricmc.net/develop
 #
-minecraft_version=1.21.5
-loader_version=0.16.13
-fabric_version=0.120.0+1.21.5
+minecraft_version=1.21.6
+loader_version=0.16.14
+fabric_version=0.128.1+1.21.6
 
 #
 # Forge
@@ -50,11 +50,11 @@ junit_jupiter_version        = 5.11.2
 #
 
 # https://github.com/lucko/fabric-permissions-api/releases
-fabric_permissions_version   = 0.3.3
+fabric_permissions_version   = 0.4.0
 
 # https://github.com/NucleoidMC/Server-Translations/releases
 # https://maven.nucleoid.xyz/xyz/nucleoid/server-translations-api/
-server_translations_version  = 2.5.0+1.21.5-rc1
+server_translations_version  = 2.5.2+1.21.6
 
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #
 # Fastback
 #
-mod_version = 0.24.2+1.21.6
+mod_version = 0.25.0+1.21.6-prerelease
 maven_group = net.pcal
 maven_name = fastback
 archives_base_name = fastback


### PR DESCRIPTION
I made a PR for https://github.com/NucleoidMC/Server-Translations/pull/67 that updates that dependency to 1.21.6 and this PR will need to wait for that to merge. That should be the only change needed to update fastback to 1.21.6