### PR TITLE
bump to minecraft 1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "architectury-plugin" version "3.4-SNAPSHOT"
-    id "dev.architectury.loom" version "1.11-SNAPSHOT" apply false
+    id "dev.architectury.loom" version "1.13-SNAPSHOT" apply false
 }
 
 architectury {

--- a/gradle.properties
+++ b/gradle.properties
@@ -67,7 +67,7 @@ server_translations_version  = 2.5.2+1.21.9-pre3
 #
 
 # https://modrinth.com/mod/architectury-api/versions
-architectury_version         = 18.0.6
+architectury_version         = 18.0.8
 org.gradle.daemon            = true
 org.gradle.parallel          = true
 org.gradle.jvmargs           = -Xmx4G

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ archives_base_name = fastback
 # Fabric & Minecraft - https://fabricmc.net/develop
 #
 minecraft_version=1.21.11
-loader_version=0.17.3
+loader_version=0.18.2
 loom_version=1.13-SNAPSHOT
 
 # Fabric API

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #
 # Fastback
 #
-mod_version = 0.30.1+1.21.11-prerelease
+mod_version = 0.30.0+1.21.11-prerelease
 maven_group = net.pcal
 maven_name = fastback
 archives_base_name = fastback

--- a/gradle.properties
+++ b/gradle.properties
@@ -67,7 +67,7 @@ server_translations_version  = 2.5.2+1.21.9-pre3
 #
 
 # https://modrinth.com/mod/architectury-api/versions
-architectury_version         = 18.0.6
+architectury_version         = 19.0.1
 org.gradle.daemon            = true
 org.gradle.parallel          = true
 org.gradle.jvmargs           = -Xmx4G

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #
 # Fastback
 #
-mod_version = 0.29.1+1.21.10-prerelease
+mod_version = 0.30.1+1.21.11-prerelease
 maven_group = net.pcal
 maven_name = fastback
 archives_base_name = fastback
@@ -10,12 +10,12 @@ archives_base_name = fastback
 #
 # Fabric & Minecraft - https://fabricmc.net/develop
 #
-minecraft_version=1.21.10
+minecraft_version=1.21.11
 loader_version=0.17.3
 loom_version=1.13-SNAPSHOT
 
 # Fabric API
-fabric_version=0.138.3+1.21.10
+fabric_version=0.139.4+1.21.11
 
 #
 # Forge
@@ -53,7 +53,7 @@ junit_jupiter_version        = 5.11.2
 #
 
 # https://github.com/lucko/fabric-permissions-api/releases
-fabric_permissions_version   = 0.5.0
+fabric_permissions_version   = 0.6.1
 
 # https://github.com/NucleoidMC/Server-Translations/releases
 # https://maven.nucleoid.xyz/xyz/nucleoid/server-translations-api/

--- a/gradle.properties
+++ b/gradle.properties
@@ -67,7 +67,7 @@ server_translations_version  = 2.5.2+1.21.9-pre3
 #
 
 # https://modrinth.com/mod/architectury-api/versions
-architectury_version         = 18.0.8
+architectury_version         = 18.0.6
 org.gradle.daemon            = true
 org.gradle.parallel          = true
 org.gradle.jvmargs           = -Xmx4G


### PR DESCRIPTION
this PR updates fastback dependencies to fix a crash caused by fabric-permissions-api-v0 on minecraft 1.21.11 (NoClassDefFoundError)

- loom from 1.11 to 1.13
- fabric-permissions-api from 0.5.0 to 0.6.1
- fabric loader from 0.17.3 to 0.18.2
- fabric api from 0.138.3 to 0.139.4
- architectury from 18.0.6 to 18.0.8
- changed fastback version from 0.29.1 to 0.30.0 cus why not

only loom and fabric-permissions-api changes were necessary to prevent crash but i went ahead and updated other dependencies as well. tested working on fabric 1.21.11 server