### PR TITLE
fix: restore failure issue

### DIFF
--- a/common/src/main/java/net/pcal/fastback/common/repo/RestoreUtils.java
+++ b/common/src/main/java/net/pcal/fastback/common/repo/RestoreUtils.java
@@ -59,7 +59,7 @@ abstract class RestoreUtils {
     // Package private
 
     static void doRestoreLocalSnapshot(final String snapshotNameToRestore, final RepoImpl repo, final UserLogger ulog) {
-        doRestoreSnapshot(snapshotNameToRestore, "file://" + mod().getWorldDirectory().toAbsolutePath(), repo, ulog);
+        doRestoreSnapshot(snapshotNameToRestore, mod().getWorldDirectory().toAbsolutePath().toUri().toString(), repo, ulog);
     }
 
     static void doRestoreRemoteSnapshot(final String snapshotNameToRestore, final RepoImpl repo, final UserLogger ulog) {
@@ -105,6 +105,10 @@ abstract class RestoreUtils {
         syslog().debug("Installing lfs locally in " + restoreTargetDirStr);
         ProcessUtils.doExec(new String[]{
                 "git", "-C", restoreTargetDirStr, "lfs", "install", "--local"
+        }, env, outputConsumer, outputConsumer);
+        syslog().debug("Fetching lfs objects from local repo " + repoUri);
+        ProcessUtils.doExec(new String[]{
+                "git", "-C", restoreTargetDirStr, "lfs", "fetch", "--all", repoUri
         }, env, outputConsumer, outputConsumer);
         syslog().debug("Checking out " + branchName + ", downloading lfs blobs");
         ProcessUtils.doExec(new String[]{


### PR DESCRIPTION
### Description

Fixes #394

This PR fixes an issue where restoring a local snapshot/backup fails because Git LFS tries to fetch missing blobs from a remote repository instead of using the local repository.

### Changes

1. **Explicitly fetch Git LFS objects**: Added `git lfs fetch --all <repoUri>` prior to the checkout process. This ensures all LFS pointers are correctly resolved and populated from the local backup repository before checking out the files.
2. **Standardize Repository URI**: Replaced the hardcoded `"file://"` string concatenation with `.toUri().toString()`. This ensures cross-platform compatibility (especially on Windows) for the repository path URI.

### Reason for the Fix

Without explicitly running `git lfs fetch`, a standard `git checkout` on an LFS-enabled repository may fail to locate the actual large files locally, prompting Git LFS to attempt a network download, which fails for local snapshots.