### PR TITLE
fix(mixin&gradle):fix mixin in common module can't debug without rema…

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -13,8 +13,6 @@ dependencies {
 	minecraft "com.mojang:minecraft:${minecraft_version}"
 
 	compileOnly "org.spongepowered:mixin:${spongepowered_version}"
-	annotationProcessor "org.spongepowered:mixin:${spongepowered_version}:processor"
-
 	testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_version}"
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_version}"
 	testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"


### PR DESCRIPTION
fix(mixin&gradle):fix mixin in common module can't debug without remap=false caused by wrong gradle confugration.
